### PR TITLE
Wipe out unnamed buffer on toggling off focusmode

### DIFF
--- a/plugin/focus.vim
+++ b/plugin/focus.vim
@@ -153,7 +153,7 @@ else
     echoerr 'g:focus_use_default_mapping set to invalid value'
 endif
 noremap <unique> <script> <Plug>FocusModeToggle <SID>ToggleFocusMode
-noremap <SID>ToggleFocusMode :call <SID>ToggleFocusMode()<CR>
+noremap <silent> <SID>ToggleFocusMode :call <SID>ToggleFocusMode()<CR>
 
 " Resetting the 'compatible' guard
 let &cpo = s:save_cpo


### PR DESCRIPTION
Focus mode leaves unnamed buffers in the buffer list when you toggle it off. Commit 3299015 fixes that. 30f9993 squashes the four commits from my previous pull request into a single commit (oops). And b493fa2 turns off recursive mapping, so the plugin doesn't break if the user remaps `<C-W>l`.
