### PR TITLE
Keep the focus buffer from resizing on 'wincmd ='

### DIFF
--- a/plugin/focus.vim
+++ b/plugin/focus.vim
@@ -70,6 +70,7 @@ function! s:CreateSideWindow(width)
     setlocal statusline=%(%)
     setfiletype focusmode
     exe "vert resize ".a:width
+    set winfixwidth
     " Jump back to the window on the right
     exe "normal! \<C-w>l"
 endfunc


### PR DESCRIPTION
`<C-W>=` / `:wincmd =` resizes the splits to be the same size, which in focus mode is undesirable behavior. This PR makes focus.vim fix the size of the left split so that doesn't happen.
